### PR TITLE
Add guidelines for linking to pages and forms

### DIFF
--- a/wordpress.md
+++ b/wordpress.md
@@ -3,3 +3,12 @@
 ## General Theme Setup
 ## Editor Styles
 ## Using Advanced Custom Fields
+## Linking to Pages and Forms in Templates
+Try to avoid linking to specific pages, posts, or forms from your template file. While using Post IDs inside templates will often work just fine, we need to make sure our templates are portable from site to site.
+
+__Rule of Thumb__: Build your templates assuming the database could get wiped out at any time or that the rows in the database could get jumbled.
+
+### Solutions
+To get around using Post IDs in template files, you can take an option-based approach. For example, create an Options page and use a [Post Object field type](http://www.advancedcustomfields.com/resources/post-object/) to allow the user to set the correct post, page, or form to load in the template.
+
+__Note__: By default, Gravity Forms are hidden from the Advanced Custom Fields Post Object field types. To combat this, use [Gravity Forms ACF Field](https://github.com/stormuk/Gravity-Forms-ACF-Field).

--- a/wordpress.md
+++ b/wordpress.md
@@ -18,16 +18,14 @@ __Note__: By default, Gravity Forms are hidden from the Advanced Custom Fields P
 __INCORRECT__:
 
 ```php
-<?php gravity_form(1, false, false, false, null, true, 99); ?>
+gravity_form(1, false, false, false, null, true, 99);
 ```
 
 __CORRECT__:
 
 ```php
-<?php
 $chosen_gravity_form = (int) get_field('contact_form', 'options');
 gravity_form($chosen_gravity_form, false, false, false, null, true, 99); ?>
-?>
 ```
 
 #### Example: Getting Child Pages
@@ -35,24 +33,20 @@ gravity_form($chosen_gravity_form, false, false, false, null, true, 99); ?>
 __INCORRECT__:
 
 ```php
-<?php
 function hm_get_team_members() {
     $team_members = hm_get_child_pages(96);
 
     return $team_members;
 }
-?>
 ```
 
 __CORRECT__:
 
 ```php
-<?php
 function hm_get_team_members() {
     $team_members_page = get_field('team_members_page', 'options');
     $team_members = hm_get_child_pages( $team_members_page->ID );
 
     return $team_members;
 }
-?>
 ```

--- a/wordpress.md
+++ b/wordpress.md
@@ -4,7 +4,7 @@
 ## Editor Styles
 ## Using Advanced Custom Fields
 ## Linking to Pages and Forms in Templates
-Try to avoid linking to specific pages, posts, or forms from your template file. While using Post IDs inside templates will often work just fine, we need to make sure our templates are portable from site to site.
+Try to avoid linking to specific pages, posts, or forms from your template file. While using Post IDs inside templates would normally work fine, we should make our templates flexible.
 
 __Rule of Thumb__: Build your templates assuming the database could get wiped out at any time or that the rows in the database could get jumbled.
 

--- a/wordpress.md
+++ b/wordpress.md
@@ -12,3 +12,47 @@ __Rule of Thumb__: Build your templates assuming the database could get wiped ou
 To get around using Post IDs in template files, you can take an option-based approach. For example, create an Options page and use a [Post Object field type](http://www.advancedcustomfields.com/resources/post-object/) to allow the user to set the correct post, page, or form to load in the template.
 
 __Note__: By default, Gravity Forms are hidden from the Advanced Custom Fields Post Object field types. To combat this, use [Gravity Forms ACF Field](https://github.com/stormuk/Gravity-Forms-ACF-Field).
+
+#### Example: Printing out a Gravity Form
+
+__INCORRECT__:
+
+```php
+<?php gravity_form(1, false, false, false, null, true, 99); ?>
+```
+
+__CORRECT__:
+
+```php
+<?php
+$chosen_gravity_form = (int) get_field('contact_form', 'options');
+gravity_form($chosen_gravity_form, false, false, false, null, true, 99); ?>
+?>
+```
+
+#### Example: Getting Child Pages
+
+__INCORRECT__:
+
+```php
+<?php
+function hm_get_team_members() {
+    $team_members = hm_get_child_pages(96);
+
+    return $team_members;
+}
+?>
+```
+
+__CORRECT__:
+
+```php
+<?php
+function hm_get_team_members() {
+    $team_members_page = get_field('team_members_page', 'options');
+    $team_members = hm_get_child_pages( $team_members_page->ID );
+
+    return $team_members;
+}
+?>
+```


### PR DESCRIPTION
We don't want to link to specific pages or forms in the templates. Here's why, and here's how to avoid it.
